### PR TITLE
Updates panoramas packages to fix redirect issue

### DIFF
--- a/pipelines/pre-deployment-pipeline.yml
+++ b/pipelines/pre-deployment-pipeline.yml
@@ -122,7 +122,7 @@ stages :
 
           - script: |
               source activate det2
-              pip install git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.2
+              pip install git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
             displayName: 'Install panorama'
           - script: |
               conda env create -f det2.yml
@@ -167,7 +167,7 @@ stages :
 
           - script: |
               source activate det2
-              pip install git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.2
+              pip install git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
             displayName: 'Install panorama'
 
           - script: |

--- a/postprocessing.Dockerfile
+++ b/postprocessing.Dockerfile
@@ -35,7 +35,7 @@ RUN pip install --no-cache \
         azure-keyvault-secrets==4.5.1 \
         azure-storage-blob==12.13.1 \
         git+https://git@github.com/Computer-Vision-Team-Amsterdam/Geolocalization_of_Street_Objects.git@faba8f6f4a94e545135dd24aea398defe2c69f97 \
-        git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@98a92686a9ef92b3748f345b137123ea5915c8b1
+        git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
 
 WORKDIR /app
 COPY visualizations/stats.py visualizations/utils.py /app/visualizations/

--- a/upload_to_postgres.Dockerfile
+++ b/upload_to_postgres.Dockerfile
@@ -10,7 +10,7 @@ RUN pip install \
     azure-keyvault-secrets==4.5.1 \
     azure-storage-blob==12.13.1 \
     psycopg2==2.8.6 \
-    git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@98a92686a9ef92b3748f345b137123ea5915c8b1
+    git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
 
 WORKDIR /opt
 COPY upload_to_postgres.py /opt


### PR DESCRIPTION
Updates panorama package to newest version.

Should fix bug where client is redirected due to missing trailing slash. Internal dependency httpx stopped following redirects in a recent update, causing get_pano to fail