### PR TITLE
Updates packages to satisfy vulnerability scanner

### DIFF
--- a/postprocessing.Dockerfile
+++ b/postprocessing.Dockerfile
@@ -22,7 +22,7 @@ RUN pip install --no-cache \
         gdal==3.2.2 \
         geojson==2.5.0 \
         geopy==2.2.0 \
-        numpy==1.21.6 \
+        numpy==1.23.5 \
         pycocotools==2.0.4 \
         requests==2.28.0 \
         pandas==1.3.5 \
@@ -30,12 +30,12 @@ RUN pip install --no-cache \
         scipy==1.7.3 \
         shapely==1.8.2 \
         tqdm==4.64.0 \
-        azure-cli==2.39.0 \
+        azure-cli==2.42.0 \
         azure-identity==1.10.0 \
         azure-keyvault-secrets==4.5.1 \
         azure-storage-blob==12.13.1 \
-        git+https://git@github.com/Computer-Vision-Team-Amsterdam/Geolocalization_of_Street_Objects.git@faba8f6f4a94e545135dd24aea398defe2c69f97 \
-        git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
+        git+https://git@github.com/Computer-Vision-Team-Amsterdam/Geolocalization_of_Street_Objects.git@17d2945ed46d40bd770ac43e0cf9f5e74f36e9ef \
+            git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
 
 WORKDIR /app
 COPY visualizations/stats.py visualizations/utils.py /app/visualizations/

--- a/postprocessing.Dockerfile
+++ b/postprocessing.Dockerfile
@@ -34,7 +34,7 @@ RUN pip install --no-cache \
         azure-identity==1.10.0 \
         azure-keyvault-secrets==4.5.1 \
         azure-storage-blob==12.13.1 \
-        git+https://git@github.com/Computer-Vision-Team-Amsterdam/Geolocalization_of_Street_Objects.git@17d2945ed46d40bd770ac43e0cf9f5e74f36e9ef \
+        git+https://git@github.com/Computer-Vision-Team-Amsterdam/Geolocalization_of_Street_Objects.git@0.1 \
             git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
 
 WORKDIR /app

--- a/postprocessing.Dockerfile
+++ b/postprocessing.Dockerfile
@@ -35,7 +35,7 @@ RUN pip install --no-cache \
         azure-keyvault-secrets==4.5.1 \
         azure-storage-blob==12.13.1 \
         git+https://git@github.com/Computer-Vision-Team-Amsterdam/Geolocalization_of_Street_Objects.git@0.1 \
-            git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
+        git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
 
 WORKDIR /app
 COPY visualizations/stats.py visualizations/utils.py /app/visualizations/

--- a/retrieve_images.Dockerfile
+++ b/retrieve_images.Dockerfile
@@ -8,7 +8,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN pip install \
     requests==2.26.0 \
-    azure-cli==2.39.0 \
+    azure-cli==2.42.0 \
     azure-identity==1.10.0 \
     azure-keyvault-secrets==4.5.1 \
     azure-storage-blob==12.13.1


### PR DESCRIPTION
Vulnerability scanner reports for [postprocessing](https://portal.azure.com/#view/Microsoft_Azure_Security_CloudNativeCompute/ImageScanReportBlade/digest/sha256%3A6ec368c69ed4b50f9a5ebcc601594c64301ea1588a401d91a1062649dccbded7/registryHost/cvtweuacrogidgmnhwma3zq.azurecr.io/repository/postprocessing/registry/cvtweuacrogidgmnhwma3zq/subscriptionId/5951db82-f968-41fb-b67c-6a78f1be5270/resourceGroup/cvt-weu-o-rg/securityStateSeverity~/4/openedFromExternalLink~/false/os/Linux) and [retrieve](https://portal.azure.com/#view/Microsoft_Azure_Security_CloudNativeCompute/ImageScanReportBlade/digest/sha256%3A1bf9f9ff6e8928398fd4506a38fce79385d2e8248a957120b4b18f618a259b6f/registryHost/cvtweuacrogidgmnhwma3zq.azurecr.io/repository/retrieve/registry/cvtweuacrogidgmnhwma3zq/subscriptionId/5951db82-f968-41fb-b67c-6a78f1be5270/resourceGroup/cvt-weu-o-rg/securityStateSeverity~/4/openedFromExternalLink~/false/os/Linux) indicated unsafe dependencies.

Bumped azure-cli, numpy, and Geolocalization_of_Street_Objects (which contains the Pillow dependency). Geolocalization_of_Street_Objects was fixed in https://github.com/Computer-Vision-Team-Amsterdam/Geolocalization_of_Street_Objects/pull/5, but dependency reference was not yet updated :)