### PR TITLE
BK-432: Ignore insert images that exist

### DIFF
--- a/inference_batch.py
+++ b/inference_batch.py
@@ -143,9 +143,6 @@ if __name__ == "__main__":
             local_file_path=f"{input_path}/{filename}",
         )
 
-    # Make a connection to the database
-    conn, cur = upload_to_postgres.connect()
-
     cfg = get_cfg()
     cfg.merge_from_file("configs/container_detection.yaml")
     cfg.DATALOADER.NUM_WORKERS = 1
@@ -201,16 +198,17 @@ if __name__ == "__main__":
         )
 
     if data_results:
-        print("Inserting data into database...")
-        table_name = "detections"
+        with upload_to_postgres.connect() as (conn, cur):
+            print("Inserting data into database...")
+            table_name = "detections"
 
-        # Get columns
-        sql = f"SELECT * FROM {table_name} LIMIT 0"
-        cur.execute(sql)
-        table_columns = [desc[0] for desc in cur.description]
-        table_columns.pop(0)  # Remove the id column
+            # Get columns
+            sql = f"SELECT * FROM {table_name} LIMIT 0"
+            cur.execute(sql)
+            table_columns = [desc[0] for desc in cur.description]
+            table_columns.pop(0)  # Remove the id column
 
-        # Inserting data into database
-        query = f"INSERT INTO {table_name} ({','.join(table_columns)}) VALUES %s"
-        execute_values(cur, query, data_results)
-        conn.commit()
+            # Inserting data into database
+            query = f"INSERT INTO {table_name} ({','.join(table_columns)}) VALUES %s"
+            execute_values(cur, query, data_results)
+            conn.commit()

--- a/inference_batch.py
+++ b/inference_batch.py
@@ -204,11 +204,11 @@ if __name__ == "__main__":
 
             # Get columns
             sql = f"SELECT * FROM {table_name} LIMIT 0"
-            cur.execute(sql)
+            cur.execute(sql)  # type: ignore
             table_columns = [desc[0] for desc in cur.description]
             table_columns.pop(0)  # Remove the id column
 
             # Inserting data into database
             query = f"INSERT INTO {table_name} ({','.join(table_columns)}) VALUES %s"
             execute_values(cur, query, data_results)
-            conn.commit()
+            conn.commit()  # type: ignore

--- a/inference_batch.py
+++ b/inference_batch.py
@@ -204,11 +204,11 @@ if __name__ == "__main__":
 
             # Get columns
             sql = f"SELECT * FROM {table_name} LIMIT 0"
-            cur.execute(sql)  # type: ignore
+            cur.execute(sql)
             table_columns = [desc[0] for desc in cur.description]
             table_columns.pop(0)  # Remove the id column
 
             # Inserting data into database
             query = f"INSERT INTO {table_name} ({','.join(table_columns)}) VALUES %s"
             execute_values(cur, query, data_results)
-            conn.commit()  # type: ignore
+            conn.commit()

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -442,7 +442,7 @@ if __name__ == "__main__":
         else:
             # Get columns
             sql = f"SELECT * FROM {table_name} LIMIT 0"
-            cur.execute(sql)
+            cur.execute(sql)  # type: ignore
             table_columns = [desc[0] for desc in cur.description]
             table_columns.pop(0)  # Remove the id column
 
@@ -453,7 +453,7 @@ if __name__ == "__main__":
             # Insert the values in the database
             sql = f"INSERT INTO {table_name} ({','.join(table_columns)}) VALUES %s"
             execute_values(cur, sql, pano_match_prioritized)
-            conn.commit()
+            conn.commit()  # type: ignore
 
             # Upload the file with found containers to the Azure Blob Storage
             for csv_file in ["prioritized_objects.csv", "permit_locations_failed.csv"]:

--- a/postprocessing.py
+++ b/postprocessing.py
@@ -442,7 +442,7 @@ if __name__ == "__main__":
         else:
             # Get columns
             sql = f"SELECT * FROM {table_name} LIMIT 0"
-            cur.execute(sql)  # type: ignore
+            cur.execute(sql)
             table_columns = [desc[0] for desc in cur.description]
             table_columns.pop(0)  # Remove the id column
 
@@ -453,7 +453,7 @@ if __name__ == "__main__":
             # Insert the values in the database
             sql = f"INSERT INTO {table_name} ({','.join(table_columns)}) VALUES %s"
             execute_values(cur, sql, pano_match_prioritized)
-            conn.commit()  # type: ignore
+            conn.commit()
 
             # Upload the file with found containers to the Azure Blob Storage
             for csv_file in ["prioritized_objects.csv", "permit_locations_failed.csv"]:

--- a/submit_to_sia.py
+++ b/submit_to_sia.py
@@ -208,16 +208,16 @@ if __name__ == "__main__":
     # Get access to the Azure Storage account.
     azure_connection = StorageAzureClient(secret_key="data-storage-account-url")
 
-    # Make a connection to the database
-    conn, cur = upload_to_postgres.connect()
-
     # Get images with a detection
     sql = (
         f"SELECT * FROM containers A LEFT JOIN images B ON A.closest_image = B.file_name "
         f"WHERE date_trunc('day', B.taken_at) = '{start_date_dag_ymd}'::date AND A.score <> 0 ORDER "
         f"BY A.score DESC LIMIT '{MAX_SIGNALS_TO_SEND}';"
     )
-    query_df = sqlio.read_sql_query(sql, conn)
+
+    with upload_to_postgres.connect() as (conn, _):
+        query_df = sqlio.read_sql_query(sql, conn)
+
     if query_df.empty:
         print(
             "DataFrame is empty! No illegal containers are found for the provided date."

--- a/upload_to_postgres.py
+++ b/upload_to_postgres.py
@@ -43,8 +43,8 @@ def connect() -> Generator[Tuple[psycopg2.extensions.connection, psycopg2.extens
     except Exception as error:
         print("Error while connecting to PostgreSQL", error)
     finally:
-        cur.close()  # type: ignore
-        conn.close()  # type: ignore
+        cur.close()
+        conn.close()
 
 
 def get_column_names(table_name: str, cur: psycopg2.extensions.cursor) -> List[str]:
@@ -58,7 +58,7 @@ def get_column_names(table_name: str, cur: psycopg2.extensions.cursor) -> List[s
     """
 
     sql = f"""SELECT * FROM {table_name}"""
-    cur.execute(sql)  # type: ignore
+    cur.execute(sql)
     cols = [desc[0] for desc in cursor.description]
 
     # currently all tables' PK have 'id' in them.

--- a/upload_to_postgres.py
+++ b/upload_to_postgres.py
@@ -132,7 +132,7 @@ def upload_images(cursor_: psycopg2.extensions.cursor, data: List[str]) -> None:
     query = f"INSERT INTO images ({','.join(keys)}) VALUES %s ON CONFLICT DO NOTHING;"
 
     rows: List[Dict[str, Union[str, float, datetime]]] = [
-        row_to_upload_from_panorama(element, keys)  # type: ignore
+        row_to_upload_from_panorama(element, keys)
         for element in data
     ]
     values = [list(item.values()) for item in rows]

--- a/upload_to_postgres.py
+++ b/upload_to_postgres.py
@@ -132,7 +132,7 @@ def upload_images(cursor_: psycopg2.extensions.cursor, data: List[str]) -> None:
     query = f"INSERT INTO images ({','.join(keys)}) VALUES %s ON CONFLICT DO NOTHING;"
 
     rows: List[Dict[str, Union[str, float, datetime]]] = [
-        row_to_upload_from_panorama(element, table_columns)  # type: ignore
+        row_to_upload_from_panorama(element, keys)  # type: ignore
         for element in data
     ]
     values = [list(item.values()) for item in rows]


### PR DESCRIPTION
- Updates SQL statement to fill images table to ignore errors when a record exists.
- Changes function that handles database connection to a context manager to guarantee connections being closed, both on a successful execution of the scripts, as well as on failure. This prevents the accumulation of dangling connections on the database.
- Some refactoring to attempt to make the distinction between inserts to the images and detections tables clearer.
- Changes database connection to [autocommit](https://www.psycopg.org/docs/connection.html#connection.autocommit) since we are committing immediately after generating a SQL statement anyway. Should also prevent long running connections/table locks when the program fails between uncommitted SQL statements.