### PR TITLE
Fix no segementation mask in postprocessing.py

### DIFF
--- a/inference_batch.py
+++ b/inference_batch.py
@@ -102,6 +102,9 @@ def instances_to_coco_json(
         }
         if has_mask:
             result["segmentation"] = rles[k]
+        else:
+            # Don't append result dict when there is no segmentation mask
+            continue
         if has_keypoints:
             # In COCO annotations,
             # keypoints coordinates are pixel indices.

--- a/inference_batch.py
+++ b/inference_batch.py
@@ -104,6 +104,7 @@ def instances_to_coco_json(
             result["segmentation"] = rles[k]
         else:
             # Don't append result dict when there is no segmentation mask
+            print(f"Detectron2 had issues with instance segmentation task for image {img_name}.")
             continue
         if has_keypoints:
             # In COCO annotations,


### PR DESCRIPTION
Thomas found this bug when reading the following data in postprocessing.py:

`[{"pano_id": "TMX7316010203-001697_pano_0000_000217.jpg", "category_id": 0, "bbox": [0.0, 0.0, 8000.0, 4000.0], "score": 1.0}, {"pano_id": "TMX7316010203-001697_pano_0000_000216.jpg", "category_id": 0, "bbox": [0.0, 0.0, 8000.0, 4000.0], "score": 1.0}, {"pano_id": "TMX7316010203-001697_pano_0000_000215.jpg", "category_id": 0, "bbox": [0.0, 0.0, 8000.0, 4000.0], "score": 1.0}, {"pano_id": "TMX7316010203-001697_pano_0000_000220.jpg", "category_id": 0, "bbox": [0.0, 0.0, 8000.0, 4000.0], "score": 1.0}]`

There is no `segmentation` key in this file, the following code will fail: https://github.com/Computer-Vision-Team-Amsterdam/Detecting-Heavy-Objects/blob/development/postprocessing.py#L192