### PR TITLE
BK-483-5: Change API query, retrieved images check for batched DAGRun

### DIFF
--- a/pipelines/pre-deployment-pipeline.yml
+++ b/pipelines/pre-deployment-pipeline.yml
@@ -126,7 +126,6 @@ stages :
               pip install git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
             displayName: 'Install panorama'
           - script: |
-#              conda env create -f det2.yml
               source activate det2
               pytest -s --cov=. --cov-report html --cov-report term-missing
             displayName: 'pytest'

--- a/pipelines/pre-deployment-pipeline.yml
+++ b/pipelines/pre-deployment-pipeline.yml
@@ -126,7 +126,7 @@ stages :
               pip install git+https://git@github.com/Computer-Vision-Team-Amsterdam/panorama.git@v0.2.3
             displayName: 'Install panorama'
           - script: |
-              conda env create -f det2.yml
+#              conda env create -f det2.yml
               source activate det2
               pytest -s --cov=. --cov-report html --cov-report term-missing
             displayName: 'pytest'

--- a/retrieve_images.py
+++ b/retrieve_images.py
@@ -134,8 +134,9 @@ def get_pano_ids(start_date_dag_ymd: str) -> Any:
     # indefinitely
     count = pano_data_all["count"]
     next_page = pano_data_all["_links"]["next"]["href"]
-    separator = "&" if "?" in next_page else "?"
-    next_page += f"{separator}limit_results={count}"
+    if next_page:
+        separator = "&" if "?" in next_page else "?"
+        next_page += f"{separator}limit_results={count}"
 
     # Exit the while loop if there is no next page
     while next_page:

--- a/retrieve_images.py
+++ b/retrieve_images.py
@@ -16,7 +16,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 from utils.azure_storage import BaseAzureClient, StorageAzureClient
-from utils.date import get_start_date
+from utils.date import get_start_date, get_yesterdays_date
 
 azClient = BaseAzureClient()
 BASE_URL = azClient.get_secret_value("CloudVpsBlurredUrl")
@@ -93,9 +93,22 @@ def download_panorama_from_cloudvps(
 def get_pano_ids(start_date_dag_ymd: str) -> Any:
     """
     Get panoramic image id's for a user defined bounding box region
+
+    N.B. Due to batch processing, a _scheduled_ DAGRun will either process data that was gathered on its start date, or
+         on the date before its start date. This is the case because the Panorama images are processed overnight, so
+         images for a given date may only become available past midnight.
+    N.B. Timestamps that contain only YY-MM-DD info are interpreted as midnight (00:00:00) on that date.
+
+    When querying all data for a Panorama mission in a batched DAGRun, we should therefore keep in mind that we do not
+    know if we have crossed midnight yet:
+        - the timestamp_before should be tomorrow at midnight, in order to get all images for the current day (in case
+          we are running a batch on the day of data collection),
+        - the timestamp_after should be yesterday at midnight, in order to get all images for the previous day (in case
+          it is past midnight after the day of data collection).
+
     """
     my_format_ymd = "%Y-%m-%d"
-    start_date = datetime.strptime(start_date_dag_ymd, my_format_ymd)
+    start_date = datetime.strptime(start_date_dag_ymd, my_format_ymd) - timedelta(days=1)
     end_date = start_date + timedelta(days=1)
     one_day_later = end_date.strftime(my_format_ymd)
 
@@ -105,10 +118,8 @@ def get_pano_ids(start_date_dag_ymd: str) -> Any:
     )
 
     response = requests.get(pano_url)
-    if response.ok:
-        pano_data_all = json.loads(response.content)
-    else:
-        response.raise_for_status()
+    response.raise_for_status()
+    pano_data_all = json.loads(response.content)
 
     pano_ids_dict = defaultdict(list)
 
@@ -119,8 +130,12 @@ def get_pano_ids(start_date_dag_ymd: str) -> Any:
         pano_id_key = pano_id.split("_")[0]
         pano_ids_dict[pano_id_key].append(pano_id)
 
-    # Check for next page with data
+    # Check for next page with data. Limit query to the maximum of the initial record count to avoid pages being added
+    # indefinitely
+    count = pano_data_all["count"]
     next_page = pano_data_all["_links"]["next"]["href"]
+    separator = "&" if "?" in next_page else "?"
+    next_page += f"{separator}limit_results={count}"
 
     # Exit the while loop if there is no next page
     while next_page:
@@ -177,11 +192,15 @@ if __name__ == "__main__":
     # The IDs of the panoramas that are previously processed are saved in retrieve-images-input
     pano_ids_processed = []
     all_blobs = saClient.list_container_content(cname="retrieve-images-input")
-    same_day_blobs = [
-        blob_name
-        for blob_name in all_blobs
-        if blob_name.split("/")[-2].startswith(start_date_dag_ymd)
-    ]
+
+    same_day_blobs = []
+    for blob_name in saClient.list_container_content(cname="retrieve-images-input"):
+        blob_name_date_prefix = blob_name.split("/")[-2]
+        if (
+                blob_name_date_prefix.startswith(start_date_dag_ymd)
+                or blob_name_date_prefix.startswith(get_yesterdays_date(start_date_dag_ymd))
+        ):
+            same_day_blobs.append(blob_name)
 
     print(f"Same day blobs: {same_day_blobs}")
     # Update output folder inside the WORKDIR of the docker container

--- a/utils/date.py
+++ b/utils/date.py
@@ -1,5 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Tuple
+
+
+YMD_FORMAT = "%Y-%m-%d"
 
 
 def get_start_date(arg_date: str) -> Tuple[str, str]:
@@ -10,7 +13,15 @@ def get_start_date(arg_date: str) -> Tuple[str, str]:
     start_date = datetime.strptime(arg_date, "%Y-%m-%d %H:%M:%S.%f")
     my_format = "%Y-%m-%d_%H-%M-%S"
     start_date_dag = start_date.strftime(my_format)
-    my_format_ymd = "%Y-%m-%d"
-    start_date_dag_ymd = start_date.strftime(my_format_ymd)
+    start_date_dag_ymd = start_date.strftime(YMD_FORMAT)
 
     return start_date_dag, start_date_dag_ymd
+
+
+def get_yesterdays_date(arg_date: str) -> str:
+    """Subtract one day from a date string formatted cf. YMD_FORMAT
+    Args:
+        ""arg_date: str = YMD_FORMAT formatted string
+    """
+    _, date_string = get_start_date(arg_date)
+    return (datetime.strptime(date_string, YMD_FORMAT) - timedelta(days=1)).strftime(YMD_FORMAT)


### PR DESCRIPTION
- Set record count on API query to ensure batch does not keep querying new records
- Set timestamps on API query to ensure Panorama's are queried for the correct dates
- Checks yesterday's processed images blobs