### PR TITLE
WIP: sends a keepalive message after every 60s of inactivity

### DIFF
--- a/upload_to_postgres.py
+++ b/upload_to_postgres.py
@@ -36,6 +36,8 @@ def connect() -> Generator[Tuple[psycopg2.extensions.connection, psycopg2.extens
             host=f"{HOST}.postgres.database.azure.com",
             port=PORT,
             database=DATABASE,
+            keepalives=True,
+            keepalives_idle=60,  # Sends a keepalive message after 60 seconds of inactivity
         )
         conn.autocommit = True
         cur: psycopg2.extensions.cursor = conn.cursor()


### PR DESCRIPTION
tries sending a keepalive message to the server when the db connection idles. might help mitigate connection time outs if there is a firewall out there actively cutting idle connections. seems like an unlikely fix, but who knows

https://www.psycopg.org/docs/module.html#psycopg2.connect
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS